### PR TITLE
Fix bux in projection_mean

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,5 +27,13 @@ Optional dependencies (only for some functionality):
 
 You should be able to install gisttools in a local environment using `pip install .`. gisttools has been tested mainly on Pyton 3.7, but all versions >= 3.6 *should* work, so If you experience errors with any of those versions, feel free to contact me.
 
+## Examples
+Load a GIST output file in table format and a PDB reference structure, and compute the average energy and entropy contribution per water molecule in the vicinity of each atom.
+
+```
+gist = gt.gist.load_gist_file("out.dat.gz", struct="benzene.pdb", eww_ref=-9.533)
+gist.projection_mean(["Eall_dens", "dTSsix_dens"])
+```
+
 ## Recent changes
 * Commit 280f39cb6806b0333bf86aa656cda90c97a1d378 introduced support for PME-GIST. Since old cpptraj versions did not split the energy into Esw and Eww, I opted to use the PME_ columns as Eww in gisttools, to ensure that the other gisttools functions work as expected. However, newer cpptraj versions do split the energy, so I undid this change in commit 2effd38b3ff6154b617b9d1cbb402404db630618. I recommend to use a new version of both cpptraj and gisttools, and use the Esw and Eww columns for GIST post-processing.

--- a/gisttools/gist.py
+++ b/gisttools/gist.py
@@ -749,6 +749,7 @@ class Gist:
             columns = [columns]
         if isinstance(centers, str) and centers == 'struct':
             centers = self.coord
+        centers = np.asarray(centers)
         if residues is None:
             residues = np.arange(centers.shape[0])
         if weighting_options is None:
@@ -757,15 +758,17 @@ class Gist:
         unique_res = OrderedDict()
         for i, r in enumerate(residues):
             unique_res.setdefault(r, []).append(i)
-        out = pd.DataFrame(index=unique_res, columns=columns)
+        out = pd.DataFrame(index=unique_res, columns=columns, dtype=float)
         temp_data = {c: self.get_total(c).values for c in columns}
+        n_solvents = self.get_total('population').values / self.n_frames
 
         with ProgressPrinter('{:.0f} % of atoms processed.', len(unique_res)) as progress:
             for resnum, res_ind in unique_res.items():
                 ind, _, dist = self.distance_to_spheres(centers[res_ind], rmax=rmax, atomic_radii=atomic_radii)
                 weights = distance_weight(dist, weighting_method, **weighting_options)
+                normalization = 1 / (np.sum(weights * n_solvents[ind]))
                 for col in columns:
-                    out.loc[resnum, col] = np.sum(temp_data[col][ind] * weights)
+                    out.loc[resnum, col] = np.sum(temp_data[col][ind] * weights) * normalization
                 progress.tick()
         return out
 

--- a/gisttools/gist.py
+++ b/gisttools/gist.py
@@ -765,7 +765,7 @@ class Gist:
                 ind, _, dist = self.distance_to_spheres(centers[res_ind], rmax=rmax, atomic_radii=atomic_radii)
                 weights = distance_weight(dist, weighting_method, **weighting_options)
                 for col in columns:
-                    out.loc[res_ind, col] = np.sum(temp_data[col][ind] * weights)
+                    out.loc[resnum, col] = np.sum(temp_data[col][ind] * weights)
                 progress.tick()
         return out
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="gisttools",
-    version="0.3",
+    version="0.4",
     description="Tools to process and visualize GIST results from cpptraj.",
     author="Franz Waibl",
     author_email="franz.waibl@uibk.ac.at",

--- a/tests/gist_test.py
+++ b/tests/gist_test.py
@@ -242,6 +242,34 @@ def test_projection_nearest_no_weight(coords_3x3x100):
         proj = gf.projection_nearest(['TEST_dens', 'voxels'], rmax=dist)
         np.testing.assert_allclose(proj.TEST_dens.values, dist + 1)
 
+
+def test_projection_mean_no_residues():
+    g = grid.Grid.centered(0, 10, .5)
+    data = np.zeros((10, 10, 10))
+    data[5:] = 1
+    population = np.ones((10, 10, 10)) * g.voxel_volume * 5
+    gf = gist.Gist(pd.DataFrame({'data_dens': data.ravel(), 'population': population.ravel()}), grid=g, n_frames=1, rho0=1.)
+    centers = [[-5, 0, 0], [5, 0, 0]]
+    np.testing.assert_allclose(
+        gf.projection_mean(['data_dens'], centers=centers).values,
+        [[0], [0.2]]
+    )
+    assert gf.projection_mean(['data_dens'], centers=centers).dtypes['data_dens'] == float
+
+
+def test_projection_mean_with_residues():
+    g = grid.Grid.centered(0, 10, .5)
+    data = np.zeros((10, 10, 10))
+    data[5:] = 1
+    population = np.ones((10, 10, 10)) * g.voxel_volume * 5
+    gf = gist.Gist(pd.DataFrame({'data_dens': data.ravel(), 'population': population.ravel()}), grid=g, n_frames=1, rho0=1.)
+    centers = [[-5, 0, 0], [5, 0, 0]]
+    np.testing.assert_allclose(
+        gf.projection_mean(['data_dens'], centers=centers, residues=[0, 0]).values,
+        [[0.1]]
+    )
+
+
 def test_rdf(dummy_gist):
     gf = dummy_gist
     pop = gf['population']


### PR DESCRIPTION
Here, resnum is the residue index and res_ind the atom indices in the structure that are part of residue resnum.
 out.loc[res_ind, col] therefore crashes as soon as we try to index with a list of atom indices higher than the maximum residue number.